### PR TITLE
Include rebuild_nix function and add bat

### DIFF
--- a/dot-zshrc
+++ b/dot-zshrc
@@ -1,6 +1,8 @@
+#!/bin/sh
+
 #eval "$(direnv hook zsh)"
 # PATH=/Users/lehoff/.nix-profile/bin:/nix/var/nix/profiles/default/bin:$PATH
-eval "$(fasd --init auto)"
+# eval "$(fasd --init auto)"
 
 function rebuild_nix {
   darwin-rebuild build --flake ./\#$1

--- a/home.nix
+++ b/home.nix
@@ -21,9 +21,22 @@
     nodePackages.npm
   ];
 
+  programs.bat.enable = true;
+
+  programs.neovim = {
+    enable = true;
+    vimAlias = true;
+    withNodeJs = true;
+    withRuby = true;
+    withPython3 = true;
+  };
+
   programs.zsh = {
     enable = true;
-    shellAliases = { ll = "ls -l"; };
+    shellAliases = {
+      ll = "ls -l";
+      cat = "bat";
+      };
     plugins = [{
       name = "zsh-nix-shell";
       file = "nix-shell.plugin.zsh";


### PR DESCRIPTION
- enables `rebuild_nix` helper. to be run with `rebuild_nix mimer`
- aliases cat to bat
- installs vim (you can remove this later if you want) 